### PR TITLE
Bugfix

### DIFF
--- a/runner/run.py
+++ b/runner/run.py
@@ -80,6 +80,7 @@ def build_project(init_active="true"):
     new_config['serialization']['annotation']['nullable'] = data['ANNOTATION']['NULLABLE']
     new_config['serialization']['annotation']['nonnull'] = data['ANNOTATION']['NONNULL']
     new_config['serialization']['fieldInitInfo']['@active'] = init_active
+    new_config['serialization']['path'] = out_dir
     tools.write_nullaway_config_in_xml(new_config, nullaway_config_path)
     os.system(build_command + " > /dev/null 2>&1")
 

--- a/runner/updatejar.py
+++ b/runner/updatejar.py
@@ -20,11 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from ast import Not
 import os
 
 root = os.path.dirname(os.path.abspath(os.getcwd()))
 os.system("cd {} && ./gradlew install --rerun-tasks".format(root))
 os.system("cd {} && ./gradlew :core:fatJar --rerun-tasks".format(root))
+if not os.path.isfile("{}".format(os.path.join(root, "runner", "jars"))):
+    os.system("mkdir {}".format(os.path.join(root, "runner", "jars")))
 os.system((
     "mv {} {}".format(os.path.join(root, "core", "build", "libs", "core.jar"),
                       os.path.join(root, "runner", "jars", "core.jar"))))


### PR DESCRIPTION
2 things:

1: updatejar.py
issue: If the directory "runner/jar" does not exist, then the script will fail to move "core.jar" to "runner/jar"
fix: I added a check to see if "runner/jar" exists. If it doesn't then create "runner/jar"

2: run.py
issue: When running "def build_project(init_active="true")", variable "new_config" is not updated with the NullAwayFix output directory. This causes the build to write to "/tmp/NullAwayFix" (default from template) instead of the output directory from "config.json"
fix: new_config now gets the output directory from "config.json"