### PR TITLE
Serialize method visibility / return type

### DIFF
--- a/scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
+++ b/scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
@@ -109,6 +109,7 @@ public class MethodInfo {
         Arrays.toString(annotFlags),
         String.valueOf(hasNullableAnnotation),
         getVisibilityOfMethod(),
+        String.valueOf(!symbol.getReturnType().isPrimitiveOrVoid()),
         Arrays.toString(parameterNames),
         uri.getPath());
   }
@@ -129,6 +130,8 @@ public class MethodInfo {
         + "nullable"
         + "\t"
         + "visibility"
+        + "\t"
+        + "non-primitive-return"
         + "\t"
         + "parameters"
         + "\t"
@@ -170,8 +173,8 @@ public class MethodInfo {
   /**
    * Return string value of visibility
    *
-   * @return "public" if public, "private" if private and "package" if the method has package
-   *     visibility.
+   * @return "public" if public, "private" if private, "protected" if protected and "package" if the
+   *     method has package visibility.
    */
   private String getVisibilityOfMethod() {
     Set<Modifier> modifiers = symbol.getModifiers();
@@ -180,6 +183,9 @@ public class MethodInfo {
     }
     if (modifiers.contains(Modifier.PRIVATE)) {
       return "private";
+    }
+    if (modifiers.contains(Modifier.PROTECTED)) {
+      return "protected";
     }
     return "package";
   }

--- a/scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
+++ b/scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
@@ -39,7 +39,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
+import javax.lang.model.element.Modifier;
 
 public class MethodInfo {
   public final Symbol.MethodSymbol symbol;
@@ -112,6 +113,8 @@ public class MethodInfo {
         + "\t"
         + hasNullableAnnotation
         + "\t"
+        + getVisibilityOfMethod()
+        + "\t"
         + Arrays.toString(parameterNames)
         + "\t"
         + uri.getPath();
@@ -131,6 +134,8 @@ public class MethodInfo {
         + "flags"
         + "\t"
         + "nullable"
+        + "\t"
+        + "visibility"
         + "\t"
         + "parameters"
         + "\t"
@@ -167,5 +172,22 @@ public class MethodInfo {
                   }
                 })
             .toArray(String[]::new);
+  }
+
+  /**
+   * Return string value of visibility
+   *
+   * @return "public" if public, "private" if private and "package" if the method has package
+   *     visibility.
+   */
+  private String getVisibilityOfMethod() {
+    Set<Modifier> modifiers = symbol.getModifiers();
+    if (modifiers.contains(Modifier.PUBLIC)) {
+      return "public";
+    }
+    if (modifiers.contains(Modifier.PRIVATE)) {
+      return "private";
+    }
+    return "package";
   }
 }

--- a/scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
+++ b/scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
@@ -99,25 +99,18 @@ public class MethodInfo {
   @Override
   public String toString() {
     Preconditions.checkArgument(symbol != null, "Should not be null at this point.");
-    return id
-        + "\t"
-        + (clazz != null ? clazz.flatName() : "null")
-        + "\t"
-        + symbol
-        + "\t"
-        + parent
-        + "\t"
-        + symbol.getParameters().size()
-        + "\t"
-        + Arrays.toString(annotFlags)
-        + "\t"
-        + hasNullableAnnotation
-        + "\t"
-        + getVisibilityOfMethod()
-        + "\t"
-        + Arrays.toString(parameterNames)
-        + "\t"
-        + uri.getPath();
+    return String.join(
+        "\t",
+        String.valueOf(id),
+        (clazz != null ? clazz.flatName() : "null"),
+        symbol.toString(),
+        String.valueOf(parent),
+        String.valueOf(symbol.getParameters().size()),
+        Arrays.toString(annotFlags),
+        String.valueOf(hasNullableAnnotation),
+        getVisibilityOfMethod(),
+        Arrays.toString(parameterNames),
+        uri.getPath());
   }
 
   public static String header() {

--- a/scanner/src/main/java/edu/ucr/cs/riple/scanner/out/TrackerNode.java
+++ b/scanner/src/main/java/edu/ucr/cs/riple/scanner/out/TrackerNode.java
@@ -58,13 +58,12 @@ public class TrackerNode {
       return null;
     }
     Symbol enclosingClass = member.enclClass();
-    return callerClass.flatName()
-        + "\t"
-        + ((callerMethod == null) ? "null" : callerMethod)
-        + "\t"
-        + member
-        + "\t"
-        + ((enclosingClass == null) ? "null" : enclosingClass.flatName());
+    return String.join(
+        "\t",
+        callerClass.flatName(),
+        ((callerMethod == null) ? "null" : callerMethod.toString()),
+        member.toString(),
+        ((enclosingClass == null) ? "null" : enclosingClass.flatName()));
   }
 
   public static String header() {

--- a/scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodInfoTest.java
+++ b/scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodInfoTest.java
@@ -72,7 +72,7 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
           + "\t"
           + "visibility"
           + "\t"
-          +  "non-primitive-return"
+          + "non-primitive-return"
           + "\t"
           + "parameters"
           + "\t"
@@ -179,6 +179,81 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
                 "true",
                 "[]",
                 "edu/ucr/A.java"))
+        .doTest();
+  }
+
+  @Test
+  public void visibilityAndReturnTypeTest() {
+    tester
+        .addSourceLines(
+            "edu/ucr/A.java",
+            "package edu.ucr;",
+            "public abstract class A {",
+            "   static Object publicMethod(){",
+            "      return new Object();",
+            "   }",
+            "   public abstract Object publicAbstractMethod();",
+            "}")
+        .addSourceLines(
+            "edu/ucr/B.java",
+            "package edu.ucr;",
+            "import javax.annotation.Nullable;",
+            "public interface B {",
+            "   void foo();",
+            "   @Nullable",
+            "   default Object run() {",
+            "       return null;",
+            "   }",
+            "}")
+        .setExpectedOutputs(
+            new MethodInfoDisplay(
+                "1",
+                "edu.ucr.A",
+                "publicMethod()",
+                "0",
+                "0",
+                "[]",
+                "false",
+                "package",
+                "true",
+                "[]",
+                "edu/ucr/A.java"),
+            new MethodInfoDisplay(
+                "2",
+                "edu.ucr.A",
+                "publicAbstractMethod()",
+                "0",
+                "0",
+                "[]",
+                "false",
+                "public",
+                "true",
+                "[]",
+                "edu/ucr/A.java"),
+            new MethodInfoDisplay(
+                "3",
+                "edu.ucr.B",
+                "foo()",
+                "0",
+                "0",
+                "[]",
+                "false",
+                "public",
+                "false",
+                "[]",
+                "edu/ucr/B.java"),
+            new MethodInfoDisplay(
+                "4",
+                "edu.ucr.B",
+                "run()",
+                "0",
+                "0",
+                "[]",
+                "true",
+                "public",
+                "true",
+                "[]",
+                "edu/ucr/B.java"))
         .doTest();
   }
 }

--- a/scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodInfoTest.java
+++ b/scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodInfoTest.java
@@ -36,13 +36,13 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
 
   private static final DisplayFactory<MethodInfoDisplay> METHOD_DISPLAY_FACTORY =
       values -> {
-        Preconditions.checkArgument(values.length == 9, "Expected to find 9 values on each line");
+        Preconditions.checkArgument(values.length == 10, "Expected to find 9 values on each line");
         // Outputs are written in Temp Directory and is not known at compile time, therefore,
         // relative paths are getting compared.
         MethodInfoDisplay display =
             new MethodInfoDisplay(
                 values[0], values[1], values[2], values[3], values[4], values[5], values[6],
-                values[7], values[8]);
+                values[7], values[8], values[9]);
         display.path = display.path.substring(display.path.indexOf("edu/ucr/"));
         return display;
       };
@@ -60,6 +60,8 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
           + "flags"
           + "\t"
           + "nullable"
+          + "\t"
+          + "visibility"
           + "\t"
           + "parameters"
           + "\t"
@@ -90,6 +92,61 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
                 "0",
                 "[]",
                 "false",
+                "public",
+                "[]",
+                "edu/ucr/A.java"))
+        .doTest();
+  }
+
+  @Test
+  public void visibilityTest() {
+    tester
+        .addSourceLines(
+            "edu/ucr/A.java",
+            "package edu.ucr;",
+            "public class A {",
+            "   public Object publicMethod(){",
+            "      return new Object();",
+            "   }",
+            "   private Object privateMethod(){",
+            "      return new Object();",
+            "   }",
+            "   Object packageMethod(){",
+            "      return new Object();",
+            "   }",
+            "}")
+        .setExpectedOutputs(
+            new MethodInfoDisplay(
+                "1",
+                "edu.ucr.A",
+                "publicMethod()",
+                "0",
+                "0",
+                "[]",
+                "false",
+                "public",
+                "[]",
+                "edu/ucr/A.java"),
+            new MethodInfoDisplay(
+                "2",
+                "edu.ucr.A",
+                "privateMethod()",
+                "0",
+                "0",
+                "[]",
+                "false",
+                "private",
+                "[]",
+                "edu/ucr/A.java"),
+            new MethodInfoDisplay(
+                "3",
+                "edu.ucr.A",
+                "packageMethod()",
+                "0",
+                "0",
+                "[]",
+                "false",
+                "package",
                 "[]",
                 "edu/ucr/A.java"))
         .doTest();

--- a/scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodInfoTest.java
+++ b/scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodInfoTest.java
@@ -36,13 +36,22 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
 
   private static final DisplayFactory<MethodInfoDisplay> METHOD_DISPLAY_FACTORY =
       values -> {
-        Preconditions.checkArgument(values.length == 10, "Expected to find 10 values on each line");
+        Preconditions.checkArgument(values.length == 11, "Expected to find 11 values on each line");
         // Outputs are written in Temp Directory and is not known at compile time, therefore,
         // relative paths are getting compared.
         MethodInfoDisplay display =
             new MethodInfoDisplay(
-                values[0], values[1], values[2], values[3], values[4], values[5], values[6],
-                values[7], values[8], values[9]);
+                values[0],
+                values[1],
+                values[2],
+                values[3],
+                values[4],
+                values[5],
+                values[6],
+                values[7],
+                values[8],
+                values[9],
+                values[10]);
         display.path = display.path.substring(display.path.indexOf("edu/ucr/"));
         return display;
       };
@@ -62,6 +71,8 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
           + "nullable"
           + "\t"
           + "visibility"
+          + "\t"
+          +  "non-primitive-return"
           + "\t"
           + "parameters"
           + "\t"
@@ -93,6 +104,7 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
                 "[]",
                 "false",
                 "public",
+                "true",
                 "[]",
                 "edu/ucr/A.java"))
         .doTest();
@@ -111,6 +123,9 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
             "   private Object privateMethod(){",
             "      return new Object();",
             "   }",
+            "   protected Object protectedMethod(){",
+            "      return new Object();",
+            "   }",
             "   Object packageMethod(){",
             "      return new Object();",
             "   }",
@@ -125,6 +140,7 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
                 "[]",
                 "false",
                 "public",
+                "true",
                 "[]",
                 "edu/ucr/A.java"),
             new MethodInfoDisplay(
@@ -136,10 +152,23 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
                 "[]",
                 "false",
                 "private",
+                "true",
                 "[]",
                 "edu/ucr/A.java"),
             new MethodInfoDisplay(
                 "3",
+                "edu.ucr.A",
+                "protectedMethod()",
+                "0",
+                "0",
+                "[]",
+                "false",
+                "protected",
+                "true",
+                "[]",
+                "edu/ucr/A.java"),
+            new MethodInfoDisplay(
+                "4",
                 "edu.ucr.A",
                 "packageMethod()",
                 "0",
@@ -147,6 +176,7 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
                 "[]",
                 "false",
                 "package",
+                "true",
                 "[]",
                 "edu/ucr/A.java"))
         .doTest();

--- a/scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodInfoTest.java
+++ b/scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodInfoTest.java
@@ -36,7 +36,7 @@ public class MethodInfoTest extends ScannerBaseTest<MethodInfoDisplay> {
 
   private static final DisplayFactory<MethodInfoDisplay> METHOD_DISPLAY_FACTORY =
       values -> {
-        Preconditions.checkArgument(values.length == 10, "Expected to find 9 values on each line");
+        Preconditions.checkArgument(values.length == 10, "Expected to find 10 values on each line");
         // Outputs are written in Temp Directory and is not known at compile time, therefore,
         // relative paths are getting compared.
         MethodInfoDisplay display =

--- a/scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodInfoDisplay.java
+++ b/scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodInfoDisplay.java
@@ -67,8 +67,7 @@ public class MethodInfoDisplay implements Display {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     MethodInfoDisplay that = (MethodInfoDisplay) o;
-    return Objects.equals(id, that.id)
-        && Objects.equals(clazz, that.clazz)
+    return Objects.equals(clazz, that.clazz)
         && Objects.equals(symbol, that.symbol)
         && Objects.equals(parent, that.parent)
         && Objects.equals(size, that.size)
@@ -82,7 +81,6 @@ public class MethodInfoDisplay implements Display {
   @Override
   public int hashCode() {
     return Objects.hash(
-        id,
         clazz,
         symbol,
         parent,

--- a/scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodInfoDisplay.java
+++ b/scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodInfoDisplay.java
@@ -81,15 +81,7 @@ public class MethodInfoDisplay implements Display {
   @Override
   public int hashCode() {
     return Objects.hash(
-        clazz,
-        symbol,
-        parent,
-        size,
-        flags,
-        hasNullableAnnotation,
-        visibility,
-        paramNames,
-        path);
+        clazz, symbol, parent, size, flags, hasNullableAnnotation, visibility, paramNames, path);
   }
 
   @Override

--- a/scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodInfoDisplay.java
+++ b/scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodInfoDisplay.java
@@ -36,6 +36,7 @@ public class MethodInfoDisplay implements Display {
   public final String flags;
   public final String hasNullableAnnotation;
   public final String visibility;
+  public final String hasNonPrimitiveReturn;
   public final String paramNames;
   public String path;
 
@@ -48,6 +49,7 @@ public class MethodInfoDisplay implements Display {
       String flags,
       String hasNullableAnnotation,
       String visibility,
+      String hasNonPrimitiveReturn,
       String paramNames,
       String path) {
     this.id = id;
@@ -58,6 +60,7 @@ public class MethodInfoDisplay implements Display {
     this.flags = flags;
     this.hasNullableAnnotation = hasNullableAnnotation;
     this.visibility = visibility;
+    this.hasNonPrimitiveReturn = hasNonPrimitiveReturn;
     this.paramNames = paramNames;
     this.path = path;
   }
@@ -74,6 +77,7 @@ public class MethodInfoDisplay implements Display {
         && Objects.equals(flags, that.flags)
         && Objects.equals(hasNullableAnnotation, that.hasNullableAnnotation)
         && Objects.equals(visibility, that.visibility)
+        && Objects.equals(hasNonPrimitiveReturn, that.hasNonPrimitiveReturn)
         && Objects.equals(paramNames, that.paramNames)
         && Objects.equals(path, that.path);
   }
@@ -81,7 +85,16 @@ public class MethodInfoDisplay implements Display {
   @Override
   public int hashCode() {
     return Objects.hash(
-        clazz, symbol, parent, size, flags, hasNullableAnnotation, visibility, paramNames, path);
+        clazz,
+        symbol,
+        parent,
+        size,
+        flags,
+        hasNullableAnnotation,
+        visibility,
+        hasNonPrimitiveReturn,
+        paramNames,
+        path);
   }
 
   @Override
@@ -109,6 +122,9 @@ public class MethodInfoDisplay implements Display {
         + '\''
         + ", visibility='"
         + visibility
+        + '\''
+        + ", hasNonPrimitiveReturn='"
+        + hasNonPrimitiveReturn
         + '\''
         + ", paramNames='"
         + paramNames

--- a/scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodInfoDisplay.java
+++ b/scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodInfoDisplay.java
@@ -35,6 +35,7 @@ public class MethodInfoDisplay implements Display {
   public final String size;
   public final String flags;
   public final String hasNullableAnnotation;
+  public final String visibility;
   public final String paramNames;
   public String path;
 
@@ -46,6 +47,7 @@ public class MethodInfoDisplay implements Display {
       String size,
       String flags,
       String hasNullableAnnotation,
+      String visibility,
       String paramNames,
       String path) {
     this.id = id;
@@ -55,6 +57,7 @@ public class MethodInfoDisplay implements Display {
     this.size = size;
     this.flags = flags;
     this.hasNullableAnnotation = hasNullableAnnotation;
+    this.visibility = visibility;
     this.paramNames = paramNames;
     this.path = path;
   }
@@ -71,6 +74,7 @@ public class MethodInfoDisplay implements Display {
         && Objects.equals(size, that.size)
         && Objects.equals(flags, that.flags)
         && Objects.equals(hasNullableAnnotation, that.hasNullableAnnotation)
+        && Objects.equals(visibility, that.visibility)
         && Objects.equals(paramNames, that.paramNames)
         && Objects.equals(path, that.path);
   }
@@ -78,7 +82,16 @@ public class MethodInfoDisplay implements Display {
   @Override
   public int hashCode() {
     return Objects.hash(
-        id, clazz, symbol, parent, size, flags, hasNullableAnnotation, paramNames, path);
+        id,
+        clazz,
+        symbol,
+        parent,
+        size,
+        flags,
+        hasNullableAnnotation,
+        visibility,
+        paramNames,
+        path);
   }
 
   @Override
@@ -103,6 +116,9 @@ public class MethodInfoDisplay implements Display {
         + '\''
         + ", hasNullableAnnotation='"
         + hasNullableAnnotation
+        + '\''
+        + ", visibility='"
+        + visibility
         + '\''
         + ", paramNames='"
         + paramNames


### PR DESCRIPTION
This PR adds visibility and return type of method to list of informations serialized on output.

```
id, class, method, parent, size, flags, nullable, parameters, uri
```

will be changed to:

```
id, class, method, parent, size, flags, nullable, visibility, non-primitive-return, parameters, uri
```

If the method is returning a `primitive` type of `void` the `non-primitive-return` value will be set to `false` and `true` otherwise.