### PR TITLE
Prevent crash when a target class is not located with better logging mechanism.

### DIFF
--- a/core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldDeclarationAnalysis.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldDeclarationAnalysis.java
@@ -33,7 +33,7 @@ public class FieldDeclarationAnalysis extends MetaData<FieldDeclarationInfo> {
       tree = StaticJavaParser.parse(new File(path));
       NodeList<BodyDeclaration<?>> members;
       try {
-        members = Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(tree, clazz);
+        members = Helper.getTypeDeclarationMembersByFlatName(tree, clazz);
       } catch (TargetClassNotFound notFound) {
         System.err.println(notFound.getMessage());
         return null;

--- a/core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldDeclarationAnalysis.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldDeclarationAnalysis.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.google.common.collect.Sets;
 import edu.ucr.cs.riple.core.metadata.MetaData;
 import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.exceptions.TargetClassNotFound;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
@@ -30,9 +31,11 @@ public class FieldDeclarationAnalysis extends MetaData<FieldDeclarationInfo> {
     CompilationUnit tree;
     try {
       tree = StaticJavaParser.parse(new File(path));
-      NodeList<BodyDeclaration<?>> members =
-          Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(tree, clazz);
-      if (members == null) {
+      NodeList<BodyDeclaration<?>> members;
+      try {
+        members = Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(tree, clazz);
+      } catch (TargetClassNotFound notFound) {
+        System.err.println(notFound.getMessage());
         return null;
       }
       FieldDeclarationInfo info = new FieldDeclarationInfo(clazz);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -108,7 +108,7 @@ public class Helper {
   }
 
   /**
-   * Extracts the callable simple name from callable signature. (e.g. in input "run(Object i)"
+   * Extracts the callable simple name from callable signature. (e.g. on input "run(Object i)"
    * returns "run").
    *
    * @param signature callable signature in string.

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -229,10 +229,7 @@ public class Helper {
   private static Node findInnerClass(Node cursor, String name, int index)
       throws TargetClassNotFound {
     final List<Node> candidates = new ArrayList<>();
-    walk(
-        cursor,
-        candidates,
-        node -> isDeclarationWithName(node, name));
+    walk(cursor, candidates, node -> isDeclarationWithName(node, name));
     if (index >= candidates.size()) {
       throw new TargetClassNotFound("Non-Direct-Inner-Class", index + name, cursor);
     }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -232,16 +232,7 @@ public class Helper {
     walk(
         cursor,
         candidates,
-        node -> {
-          Optional<Node> parent = node.getParentNode();
-          if (parent.isEmpty()) {
-            return false;
-          }
-          if (parent.get().equals(cursor)) {
-            return false;
-          }
-          return isDeclarationWithName(node, name);
-        });
+        node -> isDeclarationWithName(node, name));
     if (index >= candidates.size()) {
       throw new TargetClassNotFound("Non-Direct-Inner-Class", index + name, cursor);
     }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -334,15 +334,16 @@ public class Helper {
   }
 
   /**
-   * Returns {@link NodeList} containing all members of an Enum/Interface/Class/Annotation
-   * Declaration by flat name from a compilation unit tree.
+   * Returns {@link NodeList} containing all members of an
+   * Enum/Interface/Class/AnonymousClass/Annotation Declaration by flat name from a compilation unit
+   * tree.
    *
    * @param cu Compilation Unit tree instance.
    * @param flatName Flat name in string.
    * @return {@link NodeList} containing all members
    * @throws TargetClassNotFound if the target class is not found.
    */
-  public static NodeList<BodyDeclaration<?>> getClassOrInterfaceOrEnumDeclarationMembersByFlatName(
+  public static NodeList<BodyDeclaration<?>> getTypeDeclarationMembersByFlatName(
       CompilationUnit cu, String flatName) throws TargetClassNotFound {
     String packageName;
     Optional<PackageDeclaration> packageDeclaration = cu.getPackageDeclaration();

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -181,7 +181,7 @@ public class Helper {
   }
 
   /**
-   * Finds Top-Level type declaration within a {@link CompilationUnit} tree by name, this node is
+   * Finds Top-Level type declaration within a {@link CompilationUnit} tree by name, this node is a
    * direct child of the compilation unit tree and can be: [{@link ClassOrInterfaceDeclaration},
    * {@link EnumDeclaration}, {@link AnnotationDeclaration}].
    *

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -53,6 +53,59 @@ import me.tongfei.progressbar.ProgressBarStyle;
 /** A utility class. */
 public class Helper {
 
+  /** Utility class to match {@link CallableDeclaration} with their signatures in {@code String}. */
+  public static class SignatureMatcher {
+
+    /** Simple name of the callable. */
+    private final String callableName;
+    /** List of parameters detected from signature in string. */
+    private final List<String> parameterTypes;
+
+    /**
+     * Constructor to make a matcher instance.
+     * @param signature Signature to process.
+     */
+    public SignatureMatcher(String signature) {
+      this.callableName = extractCallableName(signature);
+      this.parameterTypes = extractParamTypesOfCallableInString(signature);
+    }
+
+    /**
+     * Checks if callableDec's signature is equals to parsed signature.
+     *
+     * @param callableDec callable declaration node.
+     * @return true, if signature matches the callable and false otherwise.
+     */
+    public boolean matchesCallableDeclaration(CallableDeclaration<?> callableDec) {
+      // match callable names.
+      if (!callableDec.getName().toString().equals(callableName)) {
+        return false;
+      }
+      // match parameter types.
+      List<String> paramTypesFromCallableSignature =
+          extractParamTypesOfCallableInString(callableDec);
+      if (parameterTypes.size() != paramTypesFromCallableSignature.size()) {
+        return false;
+      }
+      int size = parameterTypes.size();
+      for (int i = 0; i < size; i++) {
+        String callableType = parameterTypes.get(i);
+        String signatureType = paramTypesFromCallableSignature.get(i);
+        if (signatureType.equals(callableType)) {
+          continue;
+        }
+        String simpleCallableType = simpleName(callableType);
+        String simpleSignatureType = simpleName(signatureType);
+        if (simpleCallableType.equals(simpleSignatureType)) {
+          continue;
+        }
+        // Param types are different.
+        return false;
+      }
+      return true;
+    }
+  }
+
   /**
    * Extracts the callable simple name from callable signature. (e.g. in input "run(Object i)"
    * returns "run").
@@ -80,43 +133,6 @@ public class Helper {
       }
     }
     return ans.toString();
-  }
-
-  /**
-   * Checks if callableDec's signature is equals to signature passed in the argument.
-   *
-   * @param callableDec callable declaration node.
-   * @param signature signature of the callable in string.
-   * @return true, if signature matches the callable and false otherwise.
-   */
-  public static boolean matchesCallableSignature(
-      CallableDeclaration<?> callableDec, String signature) {
-    // match simple names.
-    if (!callableDec.getName().toString().equals(extractCallableName(signature))) {
-      return false;
-    }
-    // match parameter types.
-    List<String> paramTypesFromCallableDeclaration =
-        extractParamTypesOfCallableInString(callableDec);
-    List<String> paramTypesFromCallableSignature = extractParamTypesOfCallableInString(signature);
-    if (paramTypesFromCallableDeclaration.size() != paramTypesFromCallableSignature.size()) {
-      return false;
-    }
-    int size = paramTypesFromCallableDeclaration.size();
-    for (int i = 0; i < size; i++) {
-      String callableType = paramTypesFromCallableDeclaration.get(i);
-      String signatureType = paramTypesFromCallableSignature.get(i);
-      if (signatureType.equals(callableType)) {
-        continue;
-      }
-      String simpleCallableType = simpleName(callableType);
-      String simpleSignatureType = simpleName(signatureType);
-      if (simpleCallableType.equals(simpleSignatureType)) {
-        continue;
-      }
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -74,7 +74,9 @@ public class Helper {
           --level;
           break;
         default:
-          if (level == 0) ans.append(current);
+          if (level == 0) {
+            ans.append(current);
+          }
       }
     }
     return ans.toString();

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -63,6 +63,7 @@ public class Helper {
 
     /**
      * Constructor to make a matcher instance.
+     *
      * @param signature Signature to process.
      */
     public SignatureMatcher(String signature) {

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/SignatureMatcher.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/SignatureMatcher.java
@@ -1,0 +1,163 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.ucr.cs.riple.injector;
+
+import com.github.javaparser.ast.body.CallableDeclaration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Utility class to match {@link CallableDeclaration} with their signatures in {@code String}. */
+public class SignatureMatcher {
+
+  /** Simple name of the callable. */
+  private final String callableName;
+  /** List of parameters detected from signature in string. */
+  private final List<String> parameterTypes;
+
+  /**
+   * Constructor to make a matcher instance.
+   *
+   * @param signature Signature to process.
+   */
+  public SignatureMatcher(String signature) {
+    this.callableName = Helper.extractCallableName(signature);
+    this.parameterTypes = extractParameterTypesFromSignature(signature);
+  }
+
+  /**
+   * Returns a list of parameters extracted from callable signature. (e.g. for "{@code foo(@  CustomAnnot  (exp, exp2) a.c.b.Foo<a.b.Bar, a.c.b.Foo>, java.lang.Object)}" will return "{@code [a.c.b.Foo<a.b.Bar, a.c.b.Foo>, java.lang.Object]").
+   * @param signature callable signature.
+   * @return List of extracted parameters types.
+   */
+  private static List<String> extractParameterTypesFromSignature(String signature) {
+    signature = signature.substring(signature.indexOf("("));
+    signature = signature.substring(1, signature.length() - 1);
+    int index = 0;
+    int generic_level = 0;
+    List<String> ans = new ArrayList<>();
+    StringBuilder tmp = new StringBuilder();
+    while (index < signature.length()) {
+      char c = signature.charAt(index);
+      switch (c) {
+        case '@':
+          while (signature.charAt(index + 1) == ' ' && index + 1 < signature.length()) {
+            index++;
+          }
+          int annot_level = 0;
+          boolean finished = false;
+          while (!finished && index < signature.length()) {
+            if (signature.charAt(index) == '(') {
+              ++annot_level;
+            }
+            if (signature.charAt(index) == ')') {
+              --annot_level;
+            }
+            if (signature.charAt(index) == ' ' && annot_level == 0) {
+              finished = true;
+            }
+            index++;
+          }
+          index--;
+          break;
+        case '<':
+          generic_level++;
+          tmp.append(c);
+          break;
+        case '>':
+          generic_level--;
+          tmp.append(c);
+          break;
+        case ',':
+          if (generic_level == 0) {
+            ans.add(tmp.toString());
+            tmp = new StringBuilder();
+          } else {
+            tmp.append(c);
+          }
+          break;
+        default:
+          tmp.append(c);
+      }
+      index++;
+    }
+    if (signature.length() > 0 && generic_level == 0) {
+      ans.add(tmp.toString().strip());
+    }
+    return ans;
+  }
+
+  /**
+   * Extracts parameters type from a {@link CallableDeclaration}.
+   *
+   * @param callableDec callable declaration instance.
+   * @return List of parameters type in string.
+   */
+  private static List<String> extractParameterTypesFromCallableDeclaration(
+      CallableDeclaration<?> callableDec) {
+    return callableDec.getParameters().stream()
+        .map(
+            parameter -> {
+              String type = parameter.getType().asString();
+              return parameter.isVarArgs() ? type + "..." : type;
+            })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Checks if callableDec's signature is equals to parsed signature.
+   *
+   * @param callableDec callable declaration node.
+   * @return true, if signature matches the callable and false otherwise.
+   */
+  public boolean matchesCallableDeclaration(CallableDeclaration<?> callableDec) {
+    // match callable names.
+    if (!callableDec.getName().toString().equals(callableName)) {
+      return false;
+    }
+    // match parameter types.
+    List<String> paramTypesFromCallableSignature =
+        extractParameterTypesFromCallableDeclaration(callableDec);
+    if (parameterTypes.size() != paramTypesFromCallableSignature.size()) {
+      return false;
+    }
+    int size = parameterTypes.size();
+    for (int i = 0; i < size; i++) {
+      String callableType = parameterTypes.get(i);
+      String signatureType = paramTypesFromCallableSignature.get(i);
+      if (signatureType.equals(callableType)) {
+        continue;
+      }
+      String simpleCallableType = Helper.simpleName(callableType);
+      String simpleSignatureType = Helper.simpleName(signatureType);
+      if (simpleCallableType.equals(simpleSignatureType)) {
+        continue;
+      }
+      // Param types are different.
+      return false;
+    }
+    return true;
+  }
+}

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/exceptions/TargetClassNotFound.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/exceptions/TargetClassNotFound.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 University of California, Riverside.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.ucr.cs.riple.injector.exceptions;
+
+import com.github.javaparser.ast.Node;
+
+public class TargetClassNotFound extends Exception {
+
+  static final String REPORT_MESSAGE =
+      "If you do see the class on the source code, please report this bug at: https://github.com/nimakarimipour/NullAwayAnnotator/issues. Thank you!";
+
+  public TargetClassNotFound(String type, String name, Node cursor) {
+    super(
+        "Could not find class of type: "
+            + type
+            + " with name: "
+            + name
+            + " on Cursor:\n"
+            + cursor
+            + "\n"
+            + REPORT_MESSAGE);
+  }
+}

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/exceptions/TargetClassNotFound.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/exceptions/TargetClassNotFound.java
@@ -28,7 +28,7 @@ import com.github.javaparser.ast.Node;
 public class TargetClassNotFound extends Exception {
 
   static final String REPORT_MESSAGE =
-      "If you do see the class on the source code, please report this bug at: https://github.com/nimakarimipour/NullAwayAnnotator/issues. Thank you!";
+      "If the class is in generated code or otherwise not present in the source, this is expected and this message can be safely ignored. If you do see the class on the source code, please report this bug at: https://github.com/nimakarimipour/NullAwayAnnotator/issues. Thank you!";
 
   public TargetClassNotFound(String type, String name, Node cursor) {
     super(

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/exceptions/TargetClassNotFound.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/exceptions/TargetClassNotFound.java
@@ -24,6 +24,7 @@ package edu.ucr.cs.riple.injector.exceptions;
 
 import com.github.javaparser.ast.Node;
 
+/** Exception class which should be thrown when a target class on a {@link Node} is not found. */
 public class TargetClassNotFound extends Exception {
 
   static final String REPORT_MESSAGE =

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.exceptions.TargetClassNotFound;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -88,9 +89,11 @@ public abstract class Location {
   protected abstract void fillJsonInformation(JSONObject res);
 
   public boolean apply(CompilationUnit tree, String annotation, boolean inject) {
-    NodeList<BodyDeclaration<?>> clazz =
-        Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(tree, this.clazz);
-    if (clazz == null) {
+    NodeList<BodyDeclaration<?>> clazz;
+    try {
+      clazz = Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(tree, this.clazz);
+    } catch (TargetClassNotFound notFound) {
+      System.err.println(notFound.getMessage());
       return false;
     }
     return applyToMember(clazz, annotation, inject);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -91,7 +91,7 @@ public abstract class Location {
   public boolean apply(CompilationUnit tree, String annotation, boolean inject) {
     NodeList<BodyDeclaration<?>> clazz;
     try {
-      clazz = Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(tree, this.clazz);
+      clazz = Helper.getTypeDeclarationMembersByFlatName(tree, this.clazz);
     } catch (TargetClassNotFound notFound) {
       System.err.println(notFound.getMessage());
       return false;

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
@@ -27,18 +27,19 @@ package edu.ucr.cs.riple.injector.location;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.SignatureMatcher;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.json.simple.JSONObject;
 
 public class OnMethod extends Location {
   public final String method;
-  public final Helper.SignatureMatcher matcher;
+  public final SignatureMatcher matcher;
 
   public OnMethod(String uri, String clazz, String method) {
     super(LocationType.METHOD, uri, clazz);
     this.method = method;
-    this.matcher = new Helper.SignatureMatcher(method);
+    this.matcher = new SignatureMatcher(method);
   }
 
   @Override

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
@@ -33,10 +33,12 @@ import org.json.simple.JSONObject;
 
 public class OnMethod extends Location {
   public final String method;
+  public final Helper.SignatureMatcher matcher;
 
   public OnMethod(String uri, String clazz, String method) {
     super(LocationType.METHOD, uri, clazz);
     this.method = method;
+    this.matcher = new Helper.SignatureMatcher(method);
   }
 
   @Override
@@ -58,7 +60,7 @@ public class OnMethod extends Location {
         bodyDeclaration ->
             bodyDeclaration.ifCallableDeclaration(
                 callableDeclaration -> {
-                  if (Helper.matchesCallableSignature(callableDeclaration, method)) {
+                  if (this.matcher.matchesCallableDeclaration(callableDeclaration)) {
                     applyAnnotation(callableDeclaration, annotation, inject);
                     success[0] = true;
                   }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
@@ -28,7 +28,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.SignatureMatcher;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.json.simple.JSONObject;
@@ -36,13 +36,13 @@ import org.json.simple.JSONObject;
 public class OnParameter extends Location {
   public final String method;
   public final int index;
-  private final Helper.SignatureMatcher matcher;
+  private final SignatureMatcher matcher;
 
   public OnParameter(String uri, String clazz, String method, int index) {
     super(LocationType.PARAMETER, uri, clazz);
     this.method = method;
     this.index = index;
-    this.matcher = new Helper.SignatureMatcher(method);
+    this.matcher = new SignatureMatcher(method);
   }
 
   @Override

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
@@ -36,11 +36,13 @@ import org.json.simple.JSONObject;
 public class OnParameter extends Location {
   public final String method;
   public final int index;
+  private final Helper.SignatureMatcher matcher;
 
   public OnParameter(String uri, String clazz, String method, int index) {
     super(LocationType.PARAMETER, uri, clazz);
     this.method = method;
     this.index = index;
+    this.matcher = new Helper.SignatureMatcher(method);
   }
 
   @Override
@@ -63,7 +65,7 @@ public class OnParameter extends Location {
         bodyDeclaration ->
             bodyDeclaration.ifCallableDeclaration(
                 callableDeclaration -> {
-                  if (Helper.matchesCallableSignature(callableDeclaration, method)) {
+                  if (matcher.matchesCallableDeclaration(callableDeclaration)) {
                     NodeList<?> params = callableDeclaration.getParameters();
                     if (index < params.size()) {
                       if (params.get(index) instanceof Parameter) {

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/ClassSearchTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/ClassSearchTest.java
@@ -509,9 +509,7 @@ public class ClassSearchTest extends BaseInjectorTest {
     TargetClassNotFound thrown =
         assertThrows(
             TargetClassNotFound.class,
-            () ->
-                Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(
-                    tree, "com.test.NotIncluded"));
+            () -> Helper.getTypeDeclarationMembersByFlatName(tree, "com.test.NotIncluded"));
     assertTrue(thrown.getMessage().contains(expectedErrorMessage));
   }
 }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/ClassSearchTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/ClassSearchTest.java
@@ -477,7 +477,17 @@ public class ClassSearchTest extends BaseInjectorTest {
   }
 
   @Test
-  public void proper_report_for_class_not_found_test() {
+  public void proper_report_in_err_std_for_class_not_found_test() {
+    String expectedErrorMessage =
+        "Could not find class of type: Top-Level with name: NotIncluded on Cursor:\n"
+            + "package com.test;\n"
+            + "\n"
+            + "public @interface Main {\n"
+            + "\n"
+            + "    public String foo();\n"
+            + "}\n"
+            + "\n"
+            + "If the class is in generated code or otherwise not present in the source, this is expected and this message can be safely ignored. If you do see the class on the source code, please report this bug at: https://github.com/nimakarimipour/NullAwayAnnotator/issues. Thank you!\n";
     String[] clazzLines =
         new String[] {
           "package com.test;", "public @interface Main{", "   public String foo();", "}"
@@ -493,7 +503,25 @@ public class ClassSearchTest extends BaseInjectorTest {
                 "javax.annotation.Nullable",
                 true))
         .start();
-    String errOutput = err.toString();
+    assert err.toString().equals(expectedErrorMessage);
+  }
+
+  @Test
+  public void proper_exception_check_for_class_not_found_test() {
+    String expectedErrorMessage =
+        "Could not find class of type: Top-Level with name: NotIncluded on Cursor:\n"
+            + "package com.test;\n"
+            + "\n"
+            + "public @interface Main {\n"
+            + "\n"
+            + "    public String foo();\n"
+            + "}\n"
+            + "\n"
+            + "If the class is in generated code or otherwise not present in the source, this is expected and this message can be safely ignored. If you do see the class on the source code, please report this bug at: https://github.com/nimakarimipour/NullAwayAnnotator/issues. Thank you!";
+    String[] clazzLines =
+        new String[] {
+          "package com.test;", "public @interface Main{", "   public String foo();", "}"
+        };
     CompilationUnit tree = StaticJavaParser.parse(String.join("\n", clazzLines));
     TargetClassNotFound thrown =
         assertThrows(
@@ -501,6 +529,6 @@ public class ClassSearchTest extends BaseInjectorTest {
             () ->
                 Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(
                     tree, "com.test.NotIncluded"));
-    assert thrown.getMessage().strip().equals(errOutput.strip());
+    assert thrown.getMessage().strip().equals(expectedErrorMessage.strip());
   }
 }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/ClassSearchTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/ClassSearchTest.java
@@ -25,6 +25,7 @@
 package edu.ucr.cs.riple.injector;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -478,16 +479,7 @@ public class ClassSearchTest extends BaseInjectorTest {
 
   @Test
   public void proper_report_in_err_std_for_class_not_found_test() {
-    String expectedErrorMessage =
-        "Could not find class of type: Top-Level with name: NotIncluded on Cursor:\n"
-            + "package com.test;\n"
-            + "\n"
-            + "public @interface Main {\n"
-            + "\n"
-            + "    public String foo();\n"
-            + "}\n"
-            + "\n"
-            + "If the class is in generated code or otherwise not present in the source, this is expected and this message can be safely ignored. If you do see the class on the source code, please report this bug at: https://github.com/nimakarimipour/NullAwayAnnotator/issues. Thank you!\n";
+    String expectedErrorMessage = "Could not find class of type: Top-Level with name: NotIncluded";
     String[] clazzLines =
         new String[] {
           "package com.test;", "public @interface Main{", "   public String foo();", "}"
@@ -503,21 +495,12 @@ public class ClassSearchTest extends BaseInjectorTest {
                 "javax.annotation.Nullable",
                 true))
         .start();
-    assert err.toString().equals(expectedErrorMessage);
+    assertTrue(err.toString().contains(expectedErrorMessage));
   }
 
   @Test
   public void proper_exception_check_for_class_not_found_test() {
-    String expectedErrorMessage =
-        "Could not find class of type: Top-Level with name: NotIncluded on Cursor:\n"
-            + "package com.test;\n"
-            + "\n"
-            + "public @interface Main {\n"
-            + "\n"
-            + "    public String foo();\n"
-            + "}\n"
-            + "\n"
-            + "If the class is in generated code or otherwise not present in the source, this is expected and this message can be safely ignored. If you do see the class on the source code, please report this bug at: https://github.com/nimakarimipour/NullAwayAnnotator/issues. Thank you!";
+    String expectedErrorMessage = "Could not find class of type: Top-Level with name: NotIncluded";
     String[] clazzLines =
         new String[] {
           "package com.test;", "public @interface Main{", "   public String foo();", "}"
@@ -529,6 +512,6 @@ public class ClassSearchTest extends BaseInjectorTest {
             () ->
                 Helper.getClassOrInterfaceOrEnumDeclarationMembersByFlatName(
                     tree, "com.test.NotIncluded"));
-    assert thrown.getMessage().strip().equals(expectedErrorMessage.strip());
+    assertTrue(thrown.getMessage().contains(expectedErrorMessage));
   }
 }


### PR DESCRIPTION
This PR fixes #27 by adding a new type of exception `TargetClassNotFound`. With this PR annotator will not crash if the class is not found, and will instead log this information for later debugging. 

Also added a test to verify, annotator will not fail and the desired error message is correctly reported in the `err` console.