### PR TITLE
Add Gradle command line arguments

### DIFF
--- a/core/src/test/java/edu/ucr/cs/riple/core/BaseCoreTest.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/BaseCoreTest.java
@@ -70,7 +70,7 @@ public abstract class BaseCoreTest {
           "-Pnullaway-config-path=default");
       int success = processBuilder.start().waitFor();
       if (success != 0) {
-        throw new RuntimeException("Unsuccessful creation of gradle wrapper.");
+        throw new RuntimeException("Unable to create Gradle Wrapper.");
       }
     } catch (IOException | InterruptedException e) {
       throw new RuntimeException("Preparation for test failed", e);

--- a/core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -131,22 +130,9 @@ public class CoreTestHelper {
 
   public CoreTestHelper enableDownstreamDependencyAnalysis(
       String libraryModelLoaderPath, String... dependencies) {
-    // Path to update library model
-    String libraryModelLoaderSrcRoot =
-        Utility.changeDirCommand(Paths.get(System.getProperty("user.dir")).getParent().toString());
-    this.downstreamDependencyAnalysisActivated = true;
-    this.libraryModelLoaderPath = libraryModelLoaderPath;
-    this.downstreamBuildCommands =
-        Arrays.stream(dependencies)
-            .map(
-                projectName ->
-                    String.format(
-                        "%s && ./gradlew library-model-loader:jar && %s && ./gradlew :%s:compileJava",
-                        Utility.changeDirCommand(libraryModelLoaderSrcRoot),
-                        Utility.changeDirCommand(projectPath.toString()),
-                        projectName))
-            .collect(Collectors.toSet());
-    return this;
+    // todo: Complete this function the in the follow up PRs.
+    throw new UnsupportedOperationException(
+        "This function is not implemented yet, will be updated in the follow up PRs.");
   }
 
   public void start() {
@@ -214,10 +200,25 @@ public class CoreTestHelper {
     fail(errorMessage.toString());
   }
 
+  /**
+   * Computes the build command for the project template. It includes, changing directory command
+   * from root to project root dir, command to compile the project and the computed paths to config
+   * files which will be passed through gradle command line arguments.
+   *
+   * @return The command to build the project including the command line arguments, this command can
+   *     be executed from any directory,
+   */
+  private String computeBuildCommandWithGradleCLArguments() {
+    return String.format(
+        "%s && ./gradlew compileJava -Pscanner-config-path=%s -Pnullaway-config-path=%s",
+        Utility.changeDirCommand(projectPath),
+        outDirPath.resolve("scanner.xml"),
+        outDirPath.resolve("config.xml"));
+  }
+
   private void makeAnnotatorConfigFile(Path path) {
     Config.Builder builder = new Config.Builder();
-    builder.buildCommand =
-        Utility.changeDirCommand(projectPath.toString()) + " && ./gradlew compileJava";
+    builder.buildCommand = computeBuildCommandWithGradleCLArguments();
     builder.scannerConfigPath = outDirPath.resolve("scanner.xml").toString();
     builder.nullAwayConfigPath = outDirPath.resolve("config.xml").toString();
     builder.nullableAnnotation = "javax.annotation.Nullable";

--- a/core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -218,7 +218,8 @@ public class CoreTestHelper {
 
   private void makeAnnotatorConfigFile(Path path) {
     Config.Builder builder = new Config.Builder();
-    builder.buildCommand = computeBuildCommandWithGradleCLArguments();
+    builder.buildCommand =
+        Utility.computeBuildCommandWithGradleCLArguments(this.projectPath, this.outDirPath);
     builder.scannerConfigPath = outDirPath.resolve("scanner.xml").toString();
     builder.nullAwayConfigPath = outDirPath.resolve("config.xml").toString();
     builder.nullableAnnotation = "javax.annotation.Nullable";

--- a/core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -200,22 +200,6 @@ public class CoreTestHelper {
     fail(errorMessage.toString());
   }
 
-  /**
-   * Computes the build command for the project template. It includes, changing directory command
-   * from root to project root dir, command to compile the project and the computed paths to config
-   * files which will be passed through gradle command line arguments.
-   *
-   * @return The command to build the project including the command line arguments, this command can
-   *     be executed from any directory,
-   */
-  private String computeBuildCommandWithGradleCLArguments() {
-    return String.format(
-        "%s && ./gradlew compileJava -Pscanner-config-path=%s -Pnullaway-config-path=%s",
-        Utility.changeDirCommand(projectPath),
-        outDirPath.resolve("scanner.xml"),
-        outDirPath.resolve("config.xml"));
-  }
-
   private void makeAnnotatorConfigFile(Path path) {
     Config.Builder builder = new Config.Builder();
     builder.buildCommand =

--- a/core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
@@ -35,7 +35,7 @@ public class Utility {
         Objects.requireNonNull(Utility.class.getClassLoader().getResource(relativePath)).getFile());
   }
 
-  public static String changeDirCommand(String path) {
+  public static String changeDirCommand(Path path) {
     String os = System.getProperty("os.name").toLowerCase();
     return (os.startsWith("windows") ? "dir" : "cd") + " " + path;
   }

--- a/core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
@@ -45,4 +45,22 @@ public class Utility {
     String os = System.getProperty("os.name").toLowerCase();
     return os.startsWith("windows") ? pb.command("cmd.exe", "/c") : pb.command("bash", "-c");
   }
+
+  /**
+   * Computes the build command for the project template. It includes, changing directory command
+   * from root to project root dir, command to compile the project and the computed paths to config
+   * files which will be passed through gradle command line arguments.
+   *
+   * @param projectPath Path to project directory.
+   * @param outDirPath Path to serialization output directory,
+   * @return The command to build the project including the command line arguments, this command can
+   *     * be executed from any directory.
+   */
+  public static String computeBuildCommandWithGradleCLArguments(Path projectPath, Path outDirPath) {
+    return String.format(
+        "%s && ./gradlew compileJava -Pscanner-config-path=%s -Pnullaway-config-path=%s",
+        Utility.changeDirCommand(projectPath),
+        outDirPath.resolve("scanner.xml"),
+        outDirPath.resolve("config.xml"));
+  }
 }

--- a/core/src/test/resources/templates/downstream-dependency-test/DepA/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepA/build.gradle
@@ -56,10 +56,10 @@ tasks.withType(JavaCompile) {
         options.errorprone.errorproneArgs += ["-XepDisableAllChecks",
                                               "-Xep:NullAway:ERROR",
                                               "-XepOpt:NullAway:AnnotatedPackages=edu.ucr.cs.riple.libtest",
-//                                              "-XepOpt:NullAway:SerializeFixMetadata=true",
-//                                              "-XepOpt:NullAway:FixSerializationConfigPath=",
-//                                              "-Xep:Scanner:ERROR",
-//                                              "-XepOpt:Scanner:ConfigPath=",
+                                              "-XepOpt:NullAway:SerializeFixMetadata=true",
+                                              "-XepOpt:NullAway:FixSerializationConfigPath=" + project.getProperty("nullaway-config-path"),
+                                              "-Xep:Scanner:ERROR",
+                                              "-XepOpt:Scanner:ConfigPath=" + project.getProperty("scanner-config-path"),
                                               "-XepDisableAllWarnings"]
         options.compilerArgs << "-Xmaxerrs" << "100000"
     }

--- a/core/src/test/resources/templates/downstream-dependency-test/DepB/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepB/build.gradle
@@ -56,10 +56,10 @@ tasks.withType(JavaCompile) {
         options.errorprone.errorproneArgs += ["-XepDisableAllChecks",
                                               "-Xep:NullAway:ERROR",
                                               "-XepOpt:NullAway:AnnotatedPackages=edu.ucr.cs.riple.libtest",
-//                                              "-XepOpt:NullAway:SerializeFixMetadata=true",
-//                                              "-XepOpt:NullAway:FixSerializationConfigPath=",
-//                                              "-Xep:Scanner:ERROR",
-//                                              "-XepOpt:Scanner:ConfigPath=",
+                                              "-XepOpt:NullAway:SerializeFixMetadata=true",
+                                              "-XepOpt:NullAway:FixSerializationConfigPath=" + project.getProperty("nullaway-config-path"),
+                                              "-Xep:Scanner:ERROR",
+                                              "-XepOpt:Scanner:ConfigPath=" + project.getProperty("scanner-config-path"),
                                               "-XepDisableAllWarnings"]
         options.compilerArgs << "-Xmaxerrs" << "100000"
     }

--- a/core/src/test/resources/templates/downstream-dependency-test/DepC/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepC/build.gradle
@@ -56,10 +56,10 @@ tasks.withType(JavaCompile) {
         options.errorprone.errorproneArgs += ["-XepDisableAllChecks",
                                               "-Xep:NullAway:ERROR",
                                               "-XepOpt:NullAway:AnnotatedPackages=edu.ucr.cs.riple.libtest",
-//                                              "-XepOpt:NullAway:SerializeFixMetadata=true",
-//                                              "-XepOpt:NullAway:FixSerializationConfigPath=",
-//                                              "-Xep:Scanner:ERROR",
-//                                              "-XepOpt:Scanner:ConfigPath=",
+                                              "-XepOpt:NullAway:SerializeFixMetadata=true",
+                                              "-XepOpt:NullAway:FixSerializationConfigPath=" + project.getProperty("nullaway-config-path"),
+                                              "-Xep:Scanner:ERROR",
+                                              "-XepOpt:Scanner:ConfigPath=" + project.getProperty("scanner-config-path"),
                                               "-XepDisableAllWarnings"]
         options.compilerArgs << "-Xmaxerrs" << "100000"
     }

--- a/core/src/test/resources/templates/downstream-dependency-test/Target/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/Target/build.gradle
@@ -55,10 +55,10 @@ tasks.withType(JavaCompile) {
         options.errorprone.errorproneArgs += ["-XepDisableAllChecks",
                                               "-Xep:NullAway:ERROR",
                                               "-XepOpt:NullAway:AnnotatedPackages=edu.ucr.cs.riple.libtest",
-//                                              "-XepOpt:NullAway:SerializeFixMetadata=true",
-//                                              "-XepOpt:NullAway:FixSerializationConfigPath=",
-//                                              "-Xep:Scanner:ERROR",
-//                                              "-XepOpt:Scanner:ConfigPath=",
+                                              "-XepOpt:NullAway:SerializeFixMetadata=true",
+                                              "-XepOpt:NullAway:FixSerializationConfigPath=" + project.getProperty("nullaway-config-path"),
+                                              "-Xep:Scanner:ERROR",
+                                              "-XepOpt:Scanner:ConfigPath=" + project.getProperty("scanner-config-path"),
                                               "-XepDisableAllWarnings"]
         options.compilerArgs << "-Xmaxerrs" << "100000"
     }

--- a/core/src/test/resources/templates/unittest/build.gradle
+++ b/core/src/test/resources/templates/unittest/build.gradle
@@ -58,9 +58,9 @@ tasks.withType(JavaCompile) {
                                               "-Xep:NullAway:ERROR",
                                               "-XepOpt:NullAway:AnnotatedPackages=test",
                                               "-XepOpt:NullAway:SerializeFixMetadata=true",
-                                              "-XepOpt:NullAway:FixSerializationConfigPath=",
+                                              "-XepOpt:NullAway:FixSerializationConfigPath=" + project.getProperty("nullaway-config-path"),
                                               "-Xep:Scanner:ERROR",
-                                              "-XepOpt:Scanner:ConfigPath=",
+                                              "-XepOpt:Scanner:ConfigPath=" + project.getProperty("scanner-config-path"),
                                               "-XepDisableAllWarnings"]
         options.compilerArgs << "-Xmaxerrs" << "100000"
     }


### PR DESCRIPTION
This PR address #31 by adding `gradle` command line arguments to update config files based on the values computed at runtime (e.g. path to test root directory).

This PR removes all the codes for rewriting config files.

All `build.gradle` files in test project templates, include `project.getProperty("nullaway-config-path")` and `project.getProperty("scanner-config-path")` which will be passed in build command via gradle command line arguments: `-Pscanner-config-path` and `-Pnullaway-config-path`.