### PR TITLE
Fix #38, Add UUID to every config file

### DIFF
--- a/core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -47,6 +47,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.xml.parsers.DocumentBuilder;
@@ -179,6 +180,11 @@ public class Utility {
       outputDir.setTextContent(config.outputDirectory);
       rootElement.appendChild(outputDir);
 
+      // UUID
+      Element uuid = doc.createElement("uuid");
+      uuid.setTextContent(UUID.randomUUID().toString());
+      rootElement.appendChild(uuid);
+
       // Writings
       TransformerFactory transformerFactory = TransformerFactory.newInstance();
       Transformer transformer = transformerFactory.newTransformer();
@@ -229,6 +235,11 @@ public class Utility {
       Element outputDir = doc.createElement("path");
       outputDir.setTextContent(info.dir.toString());
       rootElement.appendChild(outputDir);
+
+      // UUID
+      Element uuid = doc.createElement("uuid");
+      uuid.setTextContent(UUID.randomUUID().toString());
+      rootElement.appendChild(uuid);
 
       // Writings
       TransformerFactory transformerFactory = TransformerFactory.newInstance();

--- a/core/src/test/java/edu/ucr/cs/riple/core/ConfigurationTest.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/ConfigurationTest.java
@@ -107,7 +107,7 @@ public class ConfigurationTest {
   }
 
   @Test
-  public void test_required_flags_missing_cli() {
+  public void testRequiredFlagsMissingCli() {
     // Check if each is missed.
     for (int i = 0; i < requiredFlagsCli.size(); i++) {
       List<CLIFlag> incompleteFlags = new ArrayList<>(requiredFlagsCli);
@@ -123,7 +123,7 @@ public class ConfigurationTest {
   }
 
   @Test
-  public void test_required_flags_cli() {
+  public void testRequiredFlagsCli() {
     Config config = new Config(makeCommandLineArguments(requiredFlagsCli));
     assertEquals("./gradlew compileJava", config.buildCommand);
     assertEquals(testDir, config.globalDir);
@@ -134,7 +134,7 @@ public class ConfigurationTest {
   }
 
   @Test
-  public void test_required_flags_missing_for_downstream_dependency_analysis_cli() {
+  public void testRequiredFlagsMissingForDownstreamDependencyAnalysisCli() {
     String expectedErrorMessage =
         "To activate downstream dependency analysis, all flags [--activate-downstream-dependencies-analysis, --downstream-dependencies-build-command (arg), --nullaway-library-model-loader-path (arg)] must be present!";
     // Check if each is missed.
@@ -152,7 +152,7 @@ public class ConfigurationTest {
   }
 
   @Test
-  public void test_required_flags_for_downstream_dependency_analysis_cli() {
+  public void testRequiredFlagsForDownstreamDependencyAnalysisCli() {
     List<CLIFlag> flags = new ArrayList<>(requiredFlagsCli);
     flags.addAll(requiredDownsStreamDependencyFlagsCli);
     Config config = new Config(makeCommandLineArguments(flags));
@@ -176,7 +176,7 @@ public class ConfigurationTest {
   }
 
   @Test
-  public void test_config_files_have_different_uuid() {
+  public void testConfigFilesHaveDifferentUUID() {
     Set<String> observed = new HashSet<>();
     // Test for NullAway config
     FixSerializationConfig config = new FixSerializationConfig();


### PR DESCRIPTION
This PR resolves #38 by adding a `UUID` to every generated config file to guarantee with same configuration values, content of the file is still modified. This will trigger build systems to rebuild the module whenever annotator requests rebuilds.

Please note: `UUID` alone might not be effective unless the build systems takes the config files states into account in their caching strategies. 