### PR TITLE
Remove downstream dependency analysis from loop

### DIFF
--- a/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -98,7 +98,11 @@ public class Annotator {
     FieldDeclarationAnalysis fieldDeclarationAnalysis = new FieldDeclarationAnalysis(config.target);
     MethodInheritanceTree tree =
         new MethodInheritanceTree(config.target.dir.resolve(Serializer.METHOD_INFO_FILE_NAME));
-    // It analyzes effects of all public APIs, does not need to re-compute them per iteration.
+    // downStreamDependencyExplorer analyzes effects of all public APIs on downstream dependencies.
+    // Through iterations, since the source code for downstream dependencies does not change and the
+    // computation does not depend on the changes in the target module, it will compute the same
+    // result in each iteration, therefore we perform the analysis only once and reuse it in each
+    // iteration.
     DownStreamDependencyExplorer downStreamDependencyExplorer =
         new DownStreamDependencyExplorer(config, tree);
     if (config.downStreamDependenciesAnalysisActivated) {

--- a/library-model-loader/src/main/resources/edu/ucr/cs/riple/librarymodel/nullable-methods.tsv
+++ b/library-model-loader/src/main/resources/edu/ucr/cs/riple/librarymodel/nullable-methods.tsv
@@ -1,2 +1,0 @@
-test.target.Foo	returnNullableBad(int)
-test.target.Foo	returnNullableGood(int)


### PR DESCRIPTION
This PR removes the main part of the downstream dependency analysis from the iteration loop since the state of the downstream dependency module is not changing along the iterations. All computations are valid along the iteration can be reused.

**Note**: This assumption is valid as long as we are analyzing the whole set of public methods on downstream dependencies, by the time this changes (e.g. only analyzing methods that `NullAway` is suggesting to be `@Nullable`) we have to perform the analysis in each iteration.