### PR TITLE
Improve computation of lower bound of number of errors on downstream dependencies in fix trees

### DIFF
--- a/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -136,7 +136,8 @@ public class Annotator {
             if (config.downStreamDependenciesAnalysisActivated) {
               report.effect =
                   report.effect
-                      + downStreamDependencyExplorer.effectOnDownstreamDependencies(report.root);
+                      + downStreamDependencyExplorer.computeLowerBoundOfNumberOfErrors(
+                          report.root, report.tree);
             }
             reports.putIfAbsent(report.root, report);
             reports.get(report.root).effect = report.effect;

--- a/core/src/test/resources/templates/downstream-dependency-test/Target/src/main/java/test/target/Foo.java
+++ b/core/src/test/resources/templates/downstream-dependency-test/Target/src/main/java/test/target/Foo.java
@@ -43,11 +43,16 @@ public class Foo {
     if (i > 20 && i < 30) {
       return null;
     }
+    if (i > 30 && i < 40) {
+      return foo();
+    }
     return null;
   }
 
   public void run() {
     this.field = returnNullableBad(0);
+    // Just to make a new error for annotating foo() @Nullable.
+    this.field = foo();
   }
 
   // Making this method will resolve 5 errors here and will introduce 1 error on downstream
@@ -66,6 +71,10 @@ public class Foo {
     if (i > 20 && i < 30) {
       return null;
     }
+    return null;
+  }
+
+  public Object foo() {
     return null;
   }
 }


### PR DESCRIPTION
This PR resolves #45 by improving computing of the lower bound of number of errors on downstream dependencies in fix trees. 

With this change, annotator will consider the maximum of number of errors triggered by each node in the fix tree as the lower bound which. Previous approach only considers the effect of the root of tree which can be really far from the the real number. This PR improves that.