### PR TITLE
Update bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ Steps to reproduce the behavior: (Prefer a code snippet)
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Stacktrace**
+**Stack trace**
 If applicable, add stacktrace of the exception below.
 
 **OS (please complete the following information):**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,8 +16,8 @@ Steps to reproduce the behavior: (Prefer a code snippet)
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Stacktrace**
+If applicable, add stacktrace of the exception below.
 
 **OS (please complete the following information):**
  - OS: [e.g. iOS]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ Steps to reproduce the behavior: (Prefer a code snippet)
 A clear and concise description of what you expected to happen.
 
 **Stack trace**
-If applicable, add stacktrace of the exception below.
+If applicable, add stack trace of the exception below.
 
 **OS (please complete the following information):**
  - OS: [e.g. iOS]


### PR DESCRIPTION
`bug_report.md` contains `screen shot` section which is not applicable in to this repository, this PR replaces that with `stack trace` section.