### PR TITLE
Fix #50 by removing hard coded values and using environment variables

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -47,6 +47,12 @@ dependencies {
 
 tasks.test.dependsOn(':type-annotator-scanner:publishToMavenLocal')
 
+// Set up environment variables for test configuration tu run with the latest development version.
+tasks.test.doFirst {
+    environment "NULLAWAY_TEST_VERSION", "0.9.9"
+    environment "TYPE_ANNOTATOR_SCANNER", project.version
+}
+
 publishing {
     publications {
         shadow(MavenPublication) { publication ->

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,7 +50,7 @@ tasks.test.dependsOn(':type-annotator-scanner:publishToMavenLocal')
 // Set up environment variables for test configuration tu run with the latest development version.
 tasks.test.doFirst {
     environment "NULLAWAY_TEST_VERSION", "0.9.9"
-    environment "TYPE_ANNOTATOR_SCANNER", project.version
+    environment "TYPE_ANNOTATOR_SCANNER_VERSION", project.version
 }
 
 publishing {

--- a/core/src/test/resources/templates/downstream-dependency-test/DepA/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepA/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compileOnly project(":Target")
 
     annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER_VERSION')
     annotationProcessor files(libraryloader)
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/core/src/test/resources/templates/downstream-dependency-test/DepA/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepA/build.gradle
@@ -41,8 +41,8 @@ repositories {
 dependencies {
     compileOnly project(":Target")
 
-    annotationProcessor "com.uber.nullaway:nullaway:0.9.9"
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:1.3.3-SNAPSHOT"
+    annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
     annotationProcessor files(libraryloader)
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/core/src/test/resources/templates/downstream-dependency-test/DepB/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepB/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compileOnly project(":Target")
 
     annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER_VERSION')
     annotationProcessor files(libraryloader)
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/core/src/test/resources/templates/downstream-dependency-test/DepB/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepB/build.gradle
@@ -41,8 +41,8 @@ repositories {
 dependencies {
     compileOnly project(":Target")
 
-    annotationProcessor "com.uber.nullaway:nullaway:0.9.9"
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:1.3.3-SNAPSHOT"
+    annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
     annotationProcessor files(libraryloader)
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/core/src/test/resources/templates/downstream-dependency-test/DepC/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepC/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compileOnly project(":Target")
 
     annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER_VERSION')
     annotationProcessor files(libraryloader)
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/core/src/test/resources/templates/downstream-dependency-test/DepC/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/DepC/build.gradle
@@ -41,8 +41,8 @@ repositories {
 dependencies {
     compileOnly project(":Target")
 
-    annotationProcessor "com.uber.nullaway:nullaway:0.9.9"
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:1.3.3-SNAPSHOT"
+    annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
     annotationProcessor files(libraryloader)
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/core/src/test/resources/templates/downstream-dependency-test/Target/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/Target/build.gradle
@@ -38,8 +38,8 @@ repositories {
 
 dependencies {
 
-    annotationProcessor "com.uber.nullaway:nullaway:0.9.9"
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:1.3.3-SNAPSHOT"
+    annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
     errorprone "com.google.errorprone:error_prone_core:2.3.2"

--- a/core/src/test/resources/templates/downstream-dependency-test/Target/build.gradle
+++ b/core/src/test/resources/templates/downstream-dependency-test/Target/build.gradle
@@ -39,7 +39,7 @@ repositories {
 dependencies {
 
     annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER_VERSION')
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
     errorprone "com.google.errorprone:error_prone_core:2.3.2"

--- a/core/src/test/resources/templates/unittest/build.gradle
+++ b/core/src/test/resources/templates/unittest/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
     annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER_VERSION')
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
     errorprone "com.google.errorprone:error_prone_core:2.3.2"

--- a/core/src/test/resources/templates/unittest/build.gradle
+++ b/core/src/test/resources/templates/unittest/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
-    annotationProcessor "com.uber.nullaway:nullaway:0.9.9"
-    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:1.3.3-SNAPSHOT"
+    annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
+    annotationProcessor "edu.ucr.cs.riple.nullawayannotator:type-annotator-scanner:" + System.getenv('TYPE_ANNOTATOR_SCANNER')
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
     errorprone "com.google.errorprone:error_prone_core:2.3.2"


### PR DESCRIPTION
This PR resolves #50 by removing all hardcoded values (`NullAway` \ `TypeAnnotatorScanner` version values) and uses environment variables to set up test project templates configurations with the current development version.