### PR TITLE
Update readme to show status of CI jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Continuous Integration
 on:
   push:
     branches: [ master ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## NullAwayAnnotator
+## NullAwayAnnotator  [![Build Status](https://github.com/nimakarimipour/NullAwayAnnotator/actions/workflows/continuous-integration.yml/badge.svg)]
 ```NullAwayAnnotator``` or simply (Annotator) is a tool that can automatically infer types in source code and injects the 
 corresponding annotations to pass [NullAway](https://github.com/uber/NullAway) checks.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## NullAwayAnnotator  [![Build Status](https://github.com/nimakarimipour/NullAwayAnnotator/actions/workflows/continuous-integration.yml/badge.svg)]
+## NullAwayAnnotator  ![Build Status](https://github.com/nimakarimipour/NullAwayAnnotator/actions/workflows/continuous-integration.yml/badge.svg)
 ```NullAwayAnnotator``` or simply (Annotator) is a tool that can automatically infer types in source code and injects the 
 corresponding annotations to pass [NullAway](https://github.com/uber/NullAway) checks.
 


### PR DESCRIPTION
This PR resolves #57 by showing the status of the `CI` jobs in the landing `readme.md`.