### PR TITLE
Fix #75 by updating TOP method node id and returned overridden methods

### DIFF
--- a/core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodDeclarationTree.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodDeclarationTree.java
@@ -55,8 +55,8 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
     super.setup();
     this.classNames = new HashSet<>();
     this.nodes = new HashMap<>();
-    // The root node of this tree with id: -1.
-    nodes.put(-1, MethodNode.TOP);
+    // The root node of this tree with id: 0.
+    nodes.put(MethodNode.TOP.id, MethodNode.TOP);
   }
 
   @Override
@@ -81,7 +81,7 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
         values[7],
         Boolean.parseBoolean(values[8]));
     // If node has a non-top parent.
-    if (parentId != -1) {
+    if (parentId > 0) {
       MethodNode parent = nodes.get(parentId);
       // If parent has not been seen visited before.
       if (parent == null) {

--- a/core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodDeclarationTree.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodDeclarationTree.java
@@ -97,7 +97,7 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
   }
 
   /**
-   * Locates the immediate super method of input method.
+   * Locates the immediate super method of input method declared in module.
    *
    * @param method Method signature of input.
    * @param clazz Fully qualified name of the input method.
@@ -110,7 +110,7 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
       return null;
     }
     MethodNode parent = nodes.get(node.parent);
-    return parent.isNonTop() ? parent : null;
+    return (parent.isNonTop() && parent.location != null) ? parent : null;
   }
 
   /**

--- a/core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -32,6 +32,8 @@ import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.injector.location.OnMethod;
 import edu.ucr.cs.riple.injector.location.OnParameter;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -220,6 +222,30 @@ public class CoreTest extends BaseCoreTest {
             new TReport(new OnField("Main.java", "test.Main", singleton("field")), -6),
             new TReport(new OnMethod("Main.java", "test.Main", "returnNullableRecursive()"), -6),
             new TReport(new OnMethod("Main.java", "test.Main", "returnNullable()"), -6))
+        .start();
+  }
+
+  @Test
+  public void overrideMethodDeclaredOutsideModuleTest() {
+    coreTestHelper
+        .addInputLines(
+            "Main.java",
+            "package test;",
+            "import java.util.function.Function;",
+            "import java.util.stream.Stream;",
+            "public class Main {",
+            "   public void run() {",
+            "     Stream.of(\"Foo\").map(new Function<Object, String>() {",
+            "       @Override",
+            "       public String apply(Object o) {",
+            "         return null;",
+            "       }",
+            "     });",
+            "   }",
+            "}")
+        .toDepth(1)
+        .addExpectedReports(
+            new TReport(new OnMethod("Main.java", "test.Main$1", "apply(java.lang.Object)"), -1))
         .start();
   }
 }

--- a/core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -32,8 +32,6 @@ import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.injector.location.OnMethod;
 import edu.ucr.cs.riple.injector.location.OnParameter;
 import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/type-annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
+++ b/type-annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
@@ -46,13 +46,14 @@ public class MethodInfo {
   private final int id;
   private Boolean[] annotFlags;
   private boolean hasNullableAnnotation;
-  private int parent = -1;
+  private int parent;
 
   private MethodInfo(Symbol.MethodSymbol method, VisitorState state, ScannerContext context) {
     this.id = context.getNextMethodId();
     this.symbol = method;
     this.clazz = (method != null) ? method.enclClass() : null;
     this.uri = state.getPath().getCompilationUnit().getSourceFile().toUri();
+    this.parent = 0;
     context.visitMethod(this);
   }
 


### PR DESCRIPTION
This PR resolves #75 by updating `TOP` node id and index. Also making sure that `getClosestSuperMethod()` only returns methodNode for discovered nodes. (Declared in module)