### PR TITLE
Fix #78 by downgrading javaparser version to 3.24.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,7 +35,7 @@ def versions = [
         errorProne             : defaultErrorProneVersion,
         errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
         autoService            : "1.0-rc7",
-        javaparser             : "3.24.4",
+        javaparser             : "3.24.0",
         json                   : "1.1.1",
         guava                  : "31.0.1-jre",
         cli                    : "1.5.0",


### PR DESCRIPTION
This PR resolves #78 by downgrading javaparser to version `3.24.0`.

---
### Note: 
#78 should be open until we find a reproducible example and report back to `javaparser`.