### PR TITLE
Add missing equals to changes

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddAnnotation.java
@@ -39,4 +39,13 @@ public abstract class AddAnnotation extends Change {
     res.put("INJECT", true);
     return res;
   }
+
+  @Override
+  public boolean equals(Object other) {
+    boolean superAns = super.equals(other);
+    if (!superAns) {
+      return false;
+    }
+    return other instanceof AddAnnotation;
+  }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveAnnotation.java
@@ -56,4 +56,13 @@ public class RemoveAnnotation extends Change {
   public Change duplicate() {
     return new RemoveAnnotation(location.duplicate(), annotation);
   }
+
+  @Override
+  public boolean equals(Object other) {
+    boolean superAns = super.equals(other);
+    if (!superAns) {
+      return false;
+    }
+    return other instanceof RemoveAnnotation;
+  }
 }


### PR DESCRIPTION
This PR adds refines `equals()` definition for `Change` subclasses.