### PR TITLE
Add hashcode to Change subclasses

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddAnnotation.java
@@ -23,6 +23,7 @@
 package edu.ucr.cs.riple.injector.changes;
 
 import edu.ucr.cs.riple.injector.location.Location;
+import java.util.Objects;
 import org.json.simple.JSONObject;
 
 /** Used to add annotations on elements in source code. */
@@ -47,5 +48,10 @@ public abstract class AddAnnotation extends Change {
       return false;
     }
     return other instanceof AddAnnotation;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash("Add", super.hashCode());
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveAnnotation.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import edu.ucr.cs.riple.injector.location.Location;
+import java.util.Objects;
 import org.json.simple.JSONObject;
 
 public class RemoveAnnotation extends Change {
@@ -64,5 +65,10 @@ public class RemoveAnnotation extends Change {
       return false;
     }
     return other instanceof RemoveAnnotation;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash("Remove", super.hashCode());
   }
 }


### PR DESCRIPTION
This PR is a follow up PR for #83 where `equals()` implementation were added to subclasses of `Change` class but `hashcode` implementation was missed. This PR adds the hashcode implementation.