### PR TITLE
Add Java 21 language level support to -ll flag and document it

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,4 +98,18 @@ jobs:
           ANNOTATOR_TEST_DISABLE_PARALLEL_PROCESSING: "false"
           ANNOTATOR_TEST_DISABLE_CACHING: "false"
         run: ./gradlew :annotator-core:test --tests "edu.ucr.cs.riple.core.Java17Test"
+  parser-configuration-21:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+      - name: Build with Gradle
+        env:
+          ANNOTATOR_TEST_DISABLE_PARALLEL_PROCESSING: "false"
+          ANNOTATOR_TEST_DISABLE_CACHING: "false"
+        run: ./gradlew :annotator-core:test --tests "edu.ucr.cs.riple.core.Java21Test"
 

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -20,3 +20,4 @@ Here are all __optional__ arguments that can alter Annotator's default configura
 | `-drdl, --deactivate-region-detection-lombok`          | Deactivates region detection for Lombok. |
 | `-nna, --nonnull-annotations <arg>`                    | Adds a list of non-null annotations separated by a comma to be acknowledged by Annotator (e.g., com.example1.Nonnull,com.example2.Nonnull) |
 | `eic, enable-impact-cache`                             | Enables fixes impacts caching for next cycles. |
+| `-ll, --language-level <arg>`                          | Java language level used by the parser when reading source files. Supported values: `11`, `17`, `21`. Defaults to `17`. Use `21` when the target project uses Java 21 features such as record patterns or switch pattern matching. |

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Here are some useful __optional__ arguments that can alter the default configura
 |--------------------------------------------------------|-------------|
 | `-n,--nullable <arg>`                                  | Sets custom `@Nullable` annotation. |
 | `-rboserr, --redirect-build-output-stderr`             | Redirects build outputs to `STD Err`. |
+| `-ll, --language-level <arg>`                          | Parser language level. Supported values: `11`, `17`, `21`. Defaults to `17`. Required when the target project uses Java 21 syntax (e.g. record patterns, switch patterns). |
 
 
 To learn more about all the __optional__ arguments, please refer to [OPTIONS.md](./OPTIONS.md)

--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -96,9 +96,11 @@ shadowJar {
 // Exclude tests not supported by Java 11.
 if (JavaVersion.current().isJava11()) {
     // exclude Java17Test which is designed to test Java 17 features.
+    // exclude Java21Test which is designed to test Java 21 features.
     test {
         filter {
             excludeTestsMatching "edu.ucr.cs.riple.core.Java17Test"
+            excludeTestsMatching "edu.ucr.cs.riple.core.Java21Test"
             // temporarily exclude LombokTest until we find a solution for the issue.
             excludeTestsMatching "edu.ucr.cs.riple.core.LombokTest"
         }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -378,7 +378,7 @@ public class Config {
             "ll",
             "language-level",
             true,
-            "Java language level to use when parsing code. Supported values are 11 and 17.  Defaults to 17.");
+            "Java language level to use when parsing code. Supported values are 11, 17 and 21.  Defaults to 17.");
     languageLevelOption.setRequired(false);
     options.addOption(languageLevelOption);
 
@@ -502,6 +502,8 @@ public class Config {
         return ParserConfiguration.LanguageLevel.JAVA_11;
       case "17":
         return ParserConfiguration.LanguageLevel.JAVA_17;
+      case "21":
+        return ParserConfiguration.LanguageLevel.JAVA_21;
       default:
         throw new IllegalArgumentException("Unsupported language level: " + languageLevelString);
     }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/Java21Test.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/Java21Test.java
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.ucr.cs.riple.core;
+
+import com.github.javaparser.ParserConfiguration;
+import edu.ucr.cs.riple.core.tools.TReport;
+import edu.ucr.cs.riple.injector.location.OnField;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Tests in this class are related to Java 21 features. These tests include blocks of code that are
+ * not syntactically supported by Java 17.
+ */
+public class Java21Test extends AnnotatorBaseCoreTest {
+
+  public Java21Test() {
+    super("java-21");
+  }
+
+  @Test
+  public void recordPatternInInstanceofTest() {
+    coreTestHelper
+        .onTarget()
+        .withSourceLines(
+            "Main.java",
+            "package test;",
+            "public class Main {",
+            "   record Point(double x, double y) {}",
+            "   Object f1, f2, f3, f4;",
+            "   void foo() {",
+            "      // record pattern in instanceof - finalized in Java 21 (JEP 440)",
+            "      if (f1 instanceof Point(double x, double y)) { }",
+            "   }",
+            "}")
+        .withExpectedReports(
+            new TReport(new OnField("Main.java", "test.Main", Set.of("f1", "f2", "f3", "f4")), -4))
+        .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21)
+        .start();
+  }
+}

--- a/annotator-core/src/test/resources/templates/java-21/build.gradle
+++ b/annotator-core/src/test/resources/templates/java-21/build.gradle
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import net.ltgt.gradle.errorprone.CheckSeverity
+
+plugins{
+    id "net.ltgt.errorprone" version "4.1.0" apply false
+}
+
+subprojects {
+    apply plugin: "java"
+    apply plugin: "net.ltgt.errorprone"
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+
+    def libraryloader = project.getProperty("library-model-loader-path")
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+
+    dependencies {
+        if(project.name != "Target"){
+            compileOnly project(":Target")
+            annotationProcessor files(libraryloader)
+        }
+        annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
+        annotationProcessor "edu.ucr.cs.riple.annotator:annotator-scanner:" + System.getenv('ANNOTATOR_VERSION')
+
+        // to add @Initializer
+        compileOnly "com.uber.nullaway:nullaway-annotations:" + System.getenv('NULLAWAY_TEST_VERSION')
+        // to add jetbrains annotations (testing type use vs type declaration)
+        compileOnly 'org.jetbrains:annotations:24.0.0'
+        compileOnly "org.jspecify:jspecify:0.3.0"
+        compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+        errorprone "com.google.errorprone:error_prone_core:2.31.0"
+        errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
+    }
+
+    tasks.withType(JavaCompile) {
+        // remove the if condition if you want to run NullAway on test code
+        if (!name.toLowerCase().contains("test")) {
+            options.errorprone.disableAllChecks = true
+            options.errorprone.disableAllWarnings = true
+            options.errorprone {
+                check("NullAway", CheckSeverity.WARN)
+                check("AnnotatorScanner", CheckSeverity.WARN)
+                option("NullAway:AnnotatedPackages", "test")
+                option("NullAway:SerializeFixMetadata", "true")
+                option("NullAway:FixSerializationConfigPath", project.getProperty(project.name + "-nullaway-config-path"))
+                option("NullAway:AcknowledgeLibraryModelsOfAnnotatedCode", "true")
+                option("NullAway:JSpecifyMode", project.getProperty("jspecify"))
+                option("AnnotatorScanner:ConfigPath", project.getProperty(project.name + "-scanner-config-path"))
+            }
+        }
+        options.compilerArgs << "-Xmaxerrs" << "100000"
+        options.compilerArgs << "-Xmaxwarns" << "100000"
+        options.fork = true
+    }
+}

--- a/annotator-core/src/test/resources/templates/java-21/settings.gradle
+++ b/annotator-core/src/test/resources/templates/java-21/settings.gradle
@@ -1,0 +1,25 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+rootProject.name = 'java-21'


### PR DESCRIPTION
## Problem

The `-ll` / `--language-level` flag accepts only `"11"` and `"17"`.

Projects using Java 21 features (record patterns, switch pattern matching—stable since JEP 440/441) cause a `ParseException` before any annotation inference begins:

```

ParseException: Record patterns are not supported. Pay attention that this
feature is supported starting from 'JAVA_21' language level.

```

The bundled JavaParser already has `ParserConfiguration.LanguageLevel.JAVA_21`, but `Config.getLanguageLevel()` throws an `IllegalArgumentException` before it is ever reached.

Additionally, `-ll` is fully absent from both `README.md` and `OPTIONS.md`, making it invisible to users.

## Changes

- `Config.java`: add `case "21": return JAVA_21` and update the CLI help string.
- `OPTIONS.md`: document `-ll` in the optional flags table with default and supported values.
- `README.md`: add `-ll` to the short "useful optional arguments" table near the quick-start command example.